### PR TITLE
Making menus

### DIFF
--- a/wp-content/themes/quiltbag/functions.php
+++ b/wp-content/themes/quiltbag/functions.php
@@ -244,4 +244,14 @@ function bones_fonts() {
 
 add_action('wp_enqueue_scripts', 'bones_fonts');
 
+// **** edits by Robyn O. for QUILTBAG++ theme **** //
+
+/************* NAV MENUS *********************/
+register_nav_menus( array(
+  'main_nav' => 'Top level navigation menu',
+  'secondary_nav' => 'Some other menu somewhere else'
+) );
+
+
+
 /* DON'T DELETE THIS CLOSING TAG */ ?>

--- a/wp-content/themes/quiltbag/page-home.php
+++ b/wp-content/themes/quiltbag/page-home.php
@@ -64,7 +64,7 @@
               <p>this group is based in <span class="emphasis">NYC</span></p>
              </div>
              <!--
-            <div class="m-box m-box--nav">
+            <div class="m-box m-box - - nav"> //fix dashes if you uncomment
               <ul>
                 <li><a href="#">Code of Conduct</a></li>
                 <li><a href="#">Other Link</a></li>
@@ -74,7 +74,7 @@
             -->
             <?php
             $menu_settings = array(
-              'theme_location'  => '',
+              'theme_location'  => 'main_nav',
               'menu'            => '',
               'container'       => 'div',
               'container_class' => 'm-box m-box--nav',

--- a/wp-content/themes/quiltbag/page-home.php
+++ b/wp-content/themes/quiltbag/page-home.php
@@ -63,13 +63,37 @@
              <div class="m-box" --xs>
               <p>this group is based in <span class="emphasis">NYC</span></p>
              </div>
-             <div class="m-box m-box--nav">
+             <!--
+            <div class="m-box m-box--nav">
               <ul>
                 <li><a href="#">Code of Conduct</a></li>
                 <li><a href="#">Other Link</a></li>
                 <li><a href="#">Other Link</a></li>
               </ul>
-             </div>
+            </div>
+            -->
+            <?php
+            $menu_settings = array(
+              'theme_location'  => '',
+              'menu'            => '',
+              'container'       => 'div',
+              'container_class' => 'm-box m-box--nav',
+              'container_id'    => '',
+              'menu_class'      => 'menu',
+              'menu_id'         => '',
+              'echo'            => true,
+              'fallback_cb'     => 'wp_page_menu',
+              'before'          => '',
+              'after'           => '',
+              'link_before'     => '',
+              'link_after'      => '',
+              'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+              'depth'           => 0,
+              'walker'          => ''
+            );
+
+            wp_nav_menu( $menu_settings );
+            ?>
            </section>
 
 


### PR DESCRIPTION
Add a menu area to the home page, and register the menu in functions.php.

This change allows a WordPress admin to create a menu in the admin interface and decide where to put it in a page. 

So far, there are 2 nav menus defined (in functions.php):
- 'main_nav' => 'Top level navigation menu',
- 'secondary_nav' => 'Some other menu somewhere else'

There is only one menu location defined, however: the `main_nav` (in page-home.php) which produces the div with class `m-box--nav`. The links in the menu are the ones set in the WP admin section.

IN THE ADMIN UI:
Create/edit a menu here: http://tech.nycqueer.org/wp-admin/nav-menus.php  

... and tell WordPress where it should go: http://tech.nycqueer.org/wp-admin/nav-menus.php?action=locations
